### PR TITLE
Update openapi-config.yaml to fix typo in client name

### DIFF
--- a/openapi-config.yaml
+++ b/openapi-config.yaml
@@ -1,3 +1,3 @@
-packageName: firspass_client
+packageName: firstpass_client
 packageVersion: "0.1.0"
 projectName: firstpass-client


### PR DESCRIPTION
`firspass` --> `firstpass` :facepalm: 